### PR TITLE
Bind a volume to rabbitmq container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,11 @@ services:
   rabbitmq:
     restart: always
     image: rabbitmq:4.1.0-management-alpine
+    hostname: "codeclarity"
     env_file:
       - .env.amqp
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq/
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 10s
@@ -342,6 +345,8 @@ services:
           memory: 2G
 
 volumes:
+  rabbitmq_data:
+
   caddy_data:
   caddy_config:
 


### PR DESCRIPTION
Make sure that Rabittmq's configuration doesn't disapear if we reboot the container.

We bind a volume to the container and add a hostname.